### PR TITLE
Fix initial theme defaults to follow system preference

### DIFF
--- a/app/static/base.css
+++ b/app/static/base.css
@@ -1,4 +1,5 @@
-:root{color-scheme: light dark;--font-sans: Inter, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;--font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace}
+:root{color-scheme:light dark;--font-sans:Inter, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;--font-mono:ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;--bg:#ffffff;--fg:#0f172a;--accent:#3b82f6;--border:#00000022;--tile:color-mix(in oklab, #ffffff 92%, #000 8%)}
+@media (prefers-color-scheme: dark){:root{--bg:#0d1117;--fg:#e6edf3;--accent:#60a5fa;--border:#ffffff22;--tile:color-mix(in oklab, #0d1117 92%, #fff 8%)}}
 html[data-theme="light"]{--bg:#ffffff;--fg:#0f172a;--accent:#3b82f6;--border:#00000022;--tile:color-mix(in oklab, #ffffff 92%, #000 8%)}
 html[data-theme="dark"]{--bg:#0d1117;--fg:#e6edf3;--accent:#60a5fa;--border:#ffffff22;--tile:color-mix(in oklab, #0d1117 92%, #fff 8%)}
 html{font-family: var(--font-sans)}


### PR DESCRIPTION
## Summary
- define default theme CSS variables at the root so first-page load follows the system preference instead of an unset state
- keep explicit light and dark theme overrides for cookie-driven toggles

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68db9588a624832a8e9daeb5695d87a1