### PR TITLE
Fix coursework radial layout in production

### DIFF
--- a/app/static/base.css
+++ b/app/static/base.css
@@ -4,6 +4,11 @@ html[data-theme="light"]{--bg:#ffffff;--fg:#0f172a;--accent:#3b82f6;--border:#00
 html[data-theme="dark"]{--bg:#0d1117;--fg:#e6edf3;--accent:#60a5fa;--border:#ffffff22;--tile:color-mix(in oklab, #0d1117 92%, #fff 8%)}
 html{font-family: var(--font-sans)}
 body{margin:0;padding:0 1rem;line-height:1.7;max-width:75ch;margin-inline:auto;background:var(--bg);color:var(--fg)}
+body.wide{max-width:none;padding:0;background:var(--bg);color:var(--fg)}
+body.wide header nav,body.wide main,body.wide footer{max-width:min(1300px,95vw);margin-inline:auto;padding-inline:clamp(1.25rem,4vw,2.75rem)}
+body.wide header nav{padding-top:1.5rem;padding-bottom:1.5rem}
+body.wide main{padding-block:clamp(1.5rem,4vw,3rem)}
+body.wide footer{padding-bottom:clamp(2rem,5vw,3.5rem)}
 header nav{display:flex;gap:1rem;align-items:center;justify-content:flex-start;padding:1rem 0;border-bottom:1px solid var(--border);position:relative}
 header nav a{padding:.25rem .5rem;border-radius:.375rem;text-decoration:none}
 header nav a:hover{background:#8882}

--- a/app/static/courses.json
+++ b/app/static/courses.json
@@ -1,116 +1,279 @@
 {
-  "name": "Coursework",
-  "children": [
+  "hierarchy": {
+    "name": "Coursework",
+    "children": [
+      {
+        "name": "Physics",
+        "children": [
+          {
+            "name": "Foundations",
+            "children": [
+              { "id": "PH 102", "code": "PH 102", "name": "Physics II" },
+              { "id": "PH 110", "code": "PH 110", "name": "Physics Laboratory" },
+              { "id": "PH 201", "code": "PH 201", "name": "Mathematical Physics" },
+              { "id": "PH 202", "code": "PH 202", "name": "Electromagnetics" },
+              { "id": "PH 203", "code": "PH 203", "name": "Classical Mechanics" },
+              { "id": "PH 206", "code": "PH 206", "name": "Computational Physics" },
+              { "id": "PH 207", "code": "PH 207", "name": "Heat and Thermodynamics" }
+            ]
+          },
+          {
+            "name": "Quantum & Modern",
+            "children": [
+              { "id": "PH 204", "code": "PH 204", "name": "Quantum Mechanics" },
+              { "id": "PH 301", "code": "PH 301", "name": "Statistical Mechanics" },
+              { "id": "PH 302", "code": "PH 302", "name": "Solid State Physics" },
+              { "id": "PH 307", "code": "PH 307", "name": "Atomic and Molecular Spectroscopy" },
+              { "id": "PH 310", "code": "PH 310", "name": "Lasers and Ultrafast Optics" },
+              { "id": "PH 458", "code": "PH 458", "name": "Applied Superconductivity" },
+              { "id": "PH 462", "code": "PH 462", "name": "Quantum Technologies & Phenomena" },
+              { "id": "PH 464", "code": "PH 464", "name": "Fundamentals of Cosmology" },
+              { "id": "PH 466", "code": "PH 466", "name": "Advanced Statistical Mechanics" },
+              { "id": "PH 551", "code": "PH 551", "name": "Nonlinear Dynamics and Chaos" }
+            ]
+          },
+          {
+            "name": "Laboratories & Projects",
+            "children": [
+              { "id": "PH 312", "code": "PH 312", "name": "Mini Project" },
+              { "id": "adv-physics-lab", "code": null, "name": "Advanced Physics Laboratory" },
+              { "id": "nuclear-science", "code": null, "name": "Nuclear Science and Engineering" }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Electronics",
+        "children": [
+          {
+            "name": "Circuits & Signals",
+            "children": [
+              { "id": "EE 101", "code": "EE 101", "name": "Basic Electronics" },
+              { "id": "EEE 220", "code": "EEE 220", "name": "Signals and Systems" },
+              { "id": "PH 209", "code": "PH 209", "name": "Analog Electronics" },
+              { "id": "PH 205", "code": "PH 205", "name": "Semiconductor Devices" }
+            ]
+          },
+          {
+            "name": "Measurement & Practice",
+            "children": [
+              { "id": "PH 304", "code": "PH 304", "name": "Measurement Techniques" },
+              { "id": "PH 305", "code": "PH 305", "name": "Engineering Optics" },
+              { "id": "PH 309", "code": "PH 309", "name": "Electronics Laboratory" }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Mathematics",
+        "children": [
+          {
+            "name": "Core Theory",
+            "children": [
+              { "id": "MA 101", "code": "MA 101", "name": "Mathematics I" },
+              { "id": "MA 211M", "code": "MA 211M", "name": "Real Analysis" },
+              { "id": "MA 312M", "code": "MA 312M", "name": "Modern Algebra" }
+            ]
+          },
+          {
+            "name": "Geometry & Probability",
+            "children": [
+              { "id": "MA 212M", "code": "MA 212M", "name": "Differential Geometry" },
+              { "id": "MA 411M", "code": "MA 411M", "name": "Mathematical Statistics" }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Computer Science",
+        "children": [
+          {
+            "name": "Foundations & Systems",
+            "children": [
+              { "id": "CS 101", "code": "CS 101", "name": "Introduction to Computing" },
+              { "id": "CS 110", "code": "CS 110", "name": "Computing Lab" },
+              { "id": "CS 343", "code": "CS 343", "name": "Operating Systems" },
+              { "id": "CS 341", "code": "CS 341", "name": "Computer Networks" }
+            ]
+          },
+          {
+            "name": "Intelligent Systems",
+            "children": [
+              { "id": "CS 590", "code": "CS 590", "name": "Deep Learning" },
+              { "id": "DA 671", "code": "DA 671", "name": "Introduction to Reinforcement Learning" }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Economics",
+        "children": [
+          {
+            "name": "Economic Theory",
+            "children": [
+              { "id": "HS 123", "code": "HS 123", "name": "Game Theory and Economics" },
+              { "id": "HS 239", "code": "HS 239", "name": "Economics of Uncertainty and Information" }
+            ]
+          },
+          {
+            "name": "Behaviour & Policy",
+            "children": [
+              { "id": "HS 148", "code": "HS 148", "name": "Consumer Behaviour" },
+              { "id": "HS 200", "code": "HS 200", "name": "Sustainable Development Goals" }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Other",
+        "children": [
+          {
+            "name": "Natural Sciences",
+            "children": [
+              { "id": "CH 101", "code": "CH 101", "name": "Chemistry" },
+              { "id": "CH 110", "code": "CH 110", "name": "Chemistry Laboratory" },
+              { "id": "BT 101", "code": "BT 101", "name": "Introductory Biology" }
+            ]
+          },
+          {
+            "name": "Professional Skills",
+            "children": [
+              { "id": "CCE 101", "code": "CCE 101", "name": "Engineering Drawing I" },
+              { "id": "ME 110", "code": "ME 110", "name": "Workshop" },
+              { "id": "SA 109", "code": "SA 109", "name": "S&G Lawn Tennis" },
+              { "id": "SA 215", "code": "SA 215", "name": "Yoga-2" },
+              { "id": "SA 216", "code": "SA 216", "name": "Yoga-3" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "links": [
+    { "source": "MA 101", "target": "PH 201" },
+    { "source": "MA 101", "target": "MA 211M" },
+    { "source": "MA 101", "target": "MA 212M" },
+    { "source": "MA 101", "target": "MA 312M" },
+    { "source": "MA 101", "target": "MA 411M" },
+    { "source": "MA 211M", "target": "MA 312M" },
+    { "source": "MA 211M", "target": "MA 411M" },
+    { "source": "PH 102", "target": "PH 202" },
+    { "source": "PH 102", "target": "PH 203" },
+    { "source": "PH 102", "target": "PH 207" },
+    { "source": "PH 201", "target": "PH 204" },
+    { "source": "PH 201", "target": "PH 301" },
+    { "source": "PH 201", "target": "PH 302" },
+    { "source": "PH 202", "target": "PH 310" },
+    { "source": "PH 203", "target": "PH 204" },
+    { "source": "PH 204", "target": "PH 458" },
+    { "source": "PH 204", "target": "PH 462" },
+    { "source": "PH 204", "target": "PH 551" },
+    { "source": "PH 301", "target": "PH 466" },
+    { "source": "PH 302", "target": "PH 458" },
+    { "source": "PH 302", "target": "PH 309" },
+    { "source": "PH 205", "target": "PH 309" },
+    { "source": "PH 205", "target": "PH 312" },
+    { "source": "PH 209", "target": "PH 309" },
+    { "source": "PH 304", "target": "PH 309" },
+    { "source": "EE 101", "target": "PH 209" },
+    { "source": "EEE 220", "target": "CS 341" },
+    { "source": "CS 101", "target": "CS 341" },
+    { "source": "CS 101", "target": "CS 343" },
+    { "source": "CS 101", "target": "CS 590" },
+    { "source": "CS 101", "target": "DA 671" },
+    { "source": "CS 341", "target": "DA 671" },
+    { "source": "CS 343", "target": "CS 590" },
+    { "source": "CS 343", "target": "DA 671" },
+    { "source": "CS 590", "target": "DA 671" },
+    { "source": "CH 101", "target": "nuclear-science" },
+    { "source": "PH 310", "target": "PH 462" },
+    { "source": "PH 458", "target": "PH 462" },
+    { "source": "PH 312", "target": "adv-physics-lab" }
+  ],
+  "stages": [
     {
-      "name": "Foundations",
-      "children": [
-        { "name": "Mathematics I" },
-        { "name": "Mathematics II" },
-        { "name": "Physics I" },
-        { "name": "Mathematical Physics" },
-        { "name": "Computational Physics" }
+      "name": "Year 1 Foundations",
+      "description": "Core science, mathematics, and skills taken in the first year.",
+      "courses": [
+        "MA 101",
+        "PH 102",
+        "PH 110",
+        "CH 101",
+        "CH 110",
+        "BT 101",
+        "CS 101",
+        "CS 110",
+        "EE 101",
+        "CCE 101",
+        "ME 110",
+        "SA 109"
       ]
     },
     {
-      "name": "Quantum & Modern",
-      "children": [
-        { "name": "Quantum Mechanics" },
-        { "name": "Atomic & Molecular Spectroscopy" },
-        { "name": "Solid State Physics" },
-        { "name": "Applied Superconductivity" },
-        { "name": "Fundamentals of Cosmology" },
-        { "name": "Nuclear Science & Engineering" },
-        { "name": "Quantum Technologies (Macrosystems)" }
+      "name": "Physics Core",
+      "description": "Intermediate lecture and lab courses building analytical and experimental depth.",
+      "courses": [
+        "PH 201",
+        "PH 202",
+        "PH 203",
+        "PH 205",
+        "PH 206",
+        "PH 207",
+        "PH 209",
+        "PH 304",
+        "PH 305",
+        "PH 309"
       ]
     },
     {
-      "name": "Statistical & Thermal",
-      "children": [
-        { "name": "Statistical Mechanics" },
-        { "name": "Advanced Statistical Mechanics" },
-        { "name": "Heat & Thermodynamics" }
+      "name": "Advanced Physics & Research",
+      "description": "Specialised electives, research labs, and project work in upper years.",
+      "courses": [
+        "PH 301",
+        "PH 302",
+        "PH 307",
+        "PH 310",
+        "PH 312",
+        "PH 458",
+        "PH 462",
+        "PH 464",
+        "PH 466",
+        "PH 551",
+        "adv-physics-lab",
+        "nuclear-science"
       ]
     },
     {
-      "name": "EM & Optics",
-      "children": [
-        { "name": "Electromagnetics" },
-        { "name": "Engineering Optics" },
-        { "name": "Lasers & Ultrafast Optics" }
+      "name": "Mathematics Minor",
+      "description": "A focused collection of proof-heavy mathematics courses.",
+      "courses": [
+        "MA 211M",
+        "MA 212M",
+        "MA 312M",
+        "MA 411M"
       ]
     },
     {
-      "name": "Electronics & Instrumentation",
-      "children": [
-        { "name": "Basic Electronics" },
-        { "name": "Analog Electronics" },
-        { "name": "Digital Electronics & Microprocessors" },
-        { "name": "Electronics Laboratory" },
-        { "name": "General Physics Lab" },
-        { "name": "Measurement Techniques" },
-        { "name": "Advanced Physics Laboratory" }
+      "name": "Computing & Intelligence",
+      "description": "Systems and machine learning courses taken alongside physics work.",
+      "courses": [
+        "CS 341",
+        "CS 343",
+        "CS 590",
+        "DA 671"
       ]
     },
     {
-      "name": "Computer Science & AI",
-      "children": [
-        { "name": "Introduction to Computing" },
-        { "name": "Computing Lab" },
-        { "name": "Computer Networks" },
-        { "name": "Operating Systems" },
-        { "name": "Deep Learning" },
-        { "name": "Introduction to Reinforcement Learning" }
-      ]
-    },
-    {
-      "name": "Humanities & Economics",
-      "children": [
-        { "name": "Sustainable Development Goals" },
-        { "name": "Game Theory & Economics" },
-        { "name": "Consumer Behaviour" },
-        { "name": "Economics of Uncertainty & Information" },
-        { "name": "Public Economics" }
-      ]
-    },
-    {
-      "name": "Natural Sciences",
-      "children": [
-        { "name": "Chemistry" },
-        { "name": "Chemistry Laboratory" },
-        { "name": "Introductory Biology" }
-      ]
-    },
-    {
-      "name": "Workshops & Core Skills",
-      "children": [
-        { "name": "Engineering Drawing" },
-        { "name": "Workshop" },
-        { "name": "Engineering Mechanics" }
-      ]
-    },
-    {
-      "name": "Nonlinear & Materials",
-      "children": [
-        { "name": "Nonlinear Dynamics & Chaos" },
-        { "name": "Simulation Techniques in Physical Systems" },
-        { "name": "Electroceramics" }
-      ]
-    },
-    {
-      "name": "Projects",
-      "children": [
-        { "name": "Mini Project" }
-      ]
-    },
-    {
-      "name": "Mathematics (Minor)",
-      "children": [
-        { "name": "Real Analysis" },
-        { "name": "Mathematical Statistics" },
-        { "name": "Modern Algebra" },
-        { "name": "Differential Geometry" }
+      "name": "Economics & Humanities",
+      "description": "Courses that broadened perspectives on economics, policy, and wellbeing.",
+      "courses": [
+        "HS 123",
+        "HS 148",
+        "HS 239",
+        "HS 200",
+        "SA 215",
+        "SA 216"
       ]
     }
   ]
 }
-

--- a/app/static/coursework.css
+++ b/app/static/coursework.css
@@ -1,0 +1,108 @@
+#cw-viz.cw {
+  width: min(95vw, 1300px);
+  margin: clamp(2rem, 5vw, 4.5rem) auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.cw figure {
+  background: var(--tile);
+  border-radius: 1.2rem;
+  padding: clamp(1.25rem, 2vw, 2rem);
+  box-shadow: 0 22px 48px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cw figure h2 {
+  margin: 0;
+  font-size: clamp(1.25rem, 1.2vw + 1rem, 1.6rem);
+}
+
+.cw figure p {
+  margin: 0;
+  font-size: clamp(0.95rem, 0.4vw + 0.85rem, 1.05rem);
+  color: rgba(15, 23, 42, 0.75);
+}
+
+body.dark .cw figure p,
+html[data-theme="dark"] .cw figure p {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.cw .viz-canvas {
+  position: relative;
+  width: 100%;
+  min-height: clamp(420px, 68vh, 880px);
+  aspect-ratio: 1 / 1;
+}
+
+.cw .viz-canvas svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.cw .viz-canvas svg text {
+  font-family: var(--font-sans);
+  fill: currentColor;
+}
+
+.cw .viz-canvas svg .node-label {
+  font-size: clamp(0.66rem, 0.25vw + 0.58rem, 0.85rem);
+  letter-spacing: 0.01em;
+}
+
+.cw .viz-canvas svg .node circle {
+  stroke-width: 1.2;
+}
+
+.cw .viz-canvas svg .node.dimmed {
+  opacity: 0.18;
+}
+
+.cw .viz-canvas svg .link {
+  fill: none;
+  stroke-width: 1.25;
+}
+
+.cw .viz-canvas svg .link.dimmed {
+  opacity: 0.1;
+}
+
+.cw-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: rgba(15, 23, 42, 0.88);
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 0.55rem 0.7rem;
+  border-radius: 0.6rem;
+  font-size: 0.85rem;
+  max-width: 20rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.15);
+  display: none;
+  z-index: 5;
+  line-height: 1.4;
+}
+
+html[data-theme="dark"] .cw-tooltip,
+body.dark .cw-tooltip {
+  background: rgba(15, 23, 42, 0.85);
+  color: #f1f5f9;
+  border-color: rgba(148, 163, 184, 0.5);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.4);
+}
+
+@media (max-width: 720px) {
+  #cw-viz.cw {
+    margin: clamp(1.5rem, 10vw, 2.5rem) auto;
+    gap: 1.25rem;
+  }
+
+  .cw .viz-canvas {
+    min-height: clamp(360px, 80vw, 520px);
+  }
+}

--- a/app/static/coursework.js
+++ b/app/static/coursework.js
@@ -1,143 +1,337 @@
-// Zoomable circle packing visualization for coursework
+// Coursework radial tree visualisation powered by D3
 (function () {
-  const el = document.getElementById('cw-viz');
-  if (!el) return;
+  const mount = document.getElementById('cw-viz');
+  if (!mount || typeof d3 === 'undefined') return;
 
-  // Styles scoped to the viz
-  const style = document.createElement('style');
-  style.textContent = `
-    .cw { position: relative; width: 100%; max-width: 900px; margin: 1rem 0; }
-    .cw svg { width: 100%; height: auto; display: block; }
-    .cw .label { fill: currentColor; font: 12px/1.2 var(--font-sans); text-anchor: middle; pointer-events: none; }
-    .cw .node { cursor: pointer; }
-    .cw .node:hover { filter: brightness(1.1); }
-    .cw .tooltip { position: absolute; pointer-events: none; background: color-mix(in oklab, var(--bg) 85%, #000 15%); color: var(--fg); border: 1px solid var(--border); padding: .35rem .5rem; border-radius: .375rem; font-size: .9rem; white-space: nowrap; transform: translate(-50%, -120%); }
-  `;
-  document.head.appendChild(style);
+  const palette = new Map([
+    ['Physics', '#2563eb'],
+    ['Electronics', '#f97316'],
+    ['Mathematics', '#16a34a'],
+    ['Computer Science', '#8b5cf6'],
+    ['Economics', '#b45309'],
+    ['Other', '#64748b'],
+  ]);
+
+  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const explicitTheme = document.documentElement.dataset.theme;
+  const darkMode = explicitTheme === 'dark' || (!explicitTheme && prefersDark);
+  const surfaceColour = darkMode ? '#1f2937' : '#f8fafc';
+  const borderColour = darkMode ? 'rgba(148, 163, 184, 0.5)' : 'rgba(15, 23, 42, 0.18)';
 
   fetch('/static/courses.json', { cache: 'no-store' })
-    .then((r) => r.json())
-    .then((data) => render(data))
+    .then((response) => response.json())
+    .then((data) => init(data))
     .catch((err) => {
-      el.textContent = 'Failed to load visualization.';
-      console.error(err);
+      console.error('Failed to load coursework data', err);
+      mount.textContent = 'Failed to load visualization.';
     });
 
-  function render(data) {
-    const width = Math.min(900, el.clientWidth || 900);
-    const height = width; // square viewport
+  function init(data) {
+    const courseMap = buildCourseMap(data.hierarchy);
+    const tooltip = createTooltip(mount);
 
-    const color = d3.scaleLinear().domain([0, 5]).range(["#8ec5ff", "#3b82f6"]).interpolate(d3.interpolateHcl);
+    const radialEl = mount.querySelector('[data-viz="radial"]');
+    if (radialEl) {
+      let lastWidth = 0;
+      const render = () => {
+        const used = renderRadialTree(radialEl, data.hierarchy, courseMap, tooltip);
+        lastWidth = used;
+      };
+      render();
 
-    const pack = d3
-      .pack()
-      .size([width, height])
-      .padding(3);
+      if (typeof ResizeObserver !== 'undefined') {
+        const observer = new ResizeObserver((entries) => {
+          const entry = entries[0];
+          if (!entry) return;
+          const width = Math.round(entry.contentRect?.width || radialEl.clientWidth || 0);
+          if (!width || Math.abs(width - lastWidth) < 8) return;
+          window.requestAnimationFrame(() => render());
+        });
+        observer.observe(radialEl);
+      } else {
+        window.addEventListener('resize', debounce(render, 200));
+      }
+    }
+
+    const fallbackEl = document.getElementById('cw-fallback');
+    if (fallbackEl) fallbackEl.innerHTML = buildFallbackList(data.hierarchy);
+  }
+
+  function debounce(fn, wait) {
+    let t;
+    return () => {
+      window.clearTimeout(t);
+      t = window.setTimeout(() => fn(), wait);
+    };
+  }
+
+  function buildCourseMap(tree) {
+    const root = d3.hierarchy(structuredCloneSafe(tree));
+    const map = new Map();
+    root.each((node) => {
+      if (!node.children) {
+        const top = node.ancestors().find((a) => a.depth === 1);
+        const category = top ? top.data.name : 'Other';
+        const id = node.data.id || node.data.code || node.data.name;
+        const code = node.data.code || null;
+        const name = node.data.name;
+        const full = code ? `${code} · ${name}` : name;
+        map.set(id, { id, code, name, full, category });
+      }
+    });
+    return map;
+  }
+
+  function structuredCloneSafe(obj) {
+    if (typeof structuredClone === 'function') return structuredClone(obj);
+    return JSON.parse(JSON.stringify(obj));
+  }
+
+  function createTooltip(parent) {
+    const tip = document.createElement('div');
+    tip.className = 'cw-tooltip';
+    parent.appendChild(tip);
+    return tip;
+  }
+
+  function showTooltip(tip, event, html) {
+    const [x, y] = d3.pointer(event, event.currentTarget.closest('.viz-canvas'));
+    tip.innerHTML = html;
+    tip.style.left = `${x + 18}px`;
+    tip.style.top = `${y + 18}px`;
+    tip.style.display = 'block';
+  }
+
+  function hideTooltip(tip) {
+    tip.style.display = 'none';
+  }
+
+  function colourFor(category) {
+    return palette.get(category) || '#475569';
+  }
+
+  function formatCourse(meta) {
+    if (!meta) return '';
+    return meta.full;
+  }
+
+  function topCategory(node) {
+    if (node.depth === 0) return 'Other';
+    const top = node.ancestors().find((a) => a.depth === 1);
+    return top ? top.data.name : 'Other';
+  }
+
+  function nodeRadius(node) {
+    if (!node.children) return 5.5;
+    if (node.depth === 1) return 14;
+    return 7 + Math.sqrt(node.leaves().length);
+  }
+
+  function viewFor(node, diameter) {
+    if (!node) return [0, 0, diameter];
+    const descendants = node.descendants();
+    if (!descendants.length) return [0, 0, diameter];
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    let maxR = 0;
+    for (const d of descendants) {
+      minX = Math.min(minX, d.px);
+      maxX = Math.max(maxX, d.px);
+      minY = Math.min(minY, d.py);
+      maxY = Math.max(maxY, d.py);
+      maxR = Math.max(maxR, nodeRadius(d));
+    }
+    const span = Math.max(maxX - minX, maxY - minY) + maxR * 4;
+    const cx = (minX + maxX) / 2;
+    const cy = (minY + maxY) / 2;
+    return [cx, cy, Math.max(span, diameter / 3)];
+  }
+
+  function renderRadialTree(container, hierarchyData, courseMap, tooltip) {
+    container.innerHTML = '';
+    hideTooltip(tooltip);
+
+    const baseSize = computeBaseSize(container);
+    const margin = 90;
+    const outerRadius = baseSize / 2;
+    const innerRadius = outerRadius - margin;
+    const diameter = outerRadius * 2;
 
     const root = d3
-      .hierarchy(data)
+      .hierarchy(structuredCloneSafe(hierarchyData))
       .sum((d) => (d.children ? 0 : 1))
       .sort((a, b) => (b.value || 0) - (a.value || 0));
 
-    const nodes = pack(root).descendants();
+    const cluster = d3.cluster().size([2 * Math.PI, innerRadius]);
+    cluster(root);
+
+    root.each((node) => {
+      const angle = node.x - Math.PI / 2;
+      node.px = Math.cos(angle) * node.y;
+      node.py = Math.sin(angle) * node.y;
+    });
 
     const svg = d3
-      .select(el)
+      .select(container)
       .append('svg')
-      .attr('viewBox', [0, 0, width, height])
-      .attr('aria-label', 'Zoomable circle packing of coursework');
+      .attr('viewBox', `${-outerRadius} ${-outerRadius} ${diameter} ${diameter}`)
+      .attr('width', diameter)
+      .attr('height', diameter)
+      .attr('preserveAspectRatio', 'xMidYMid meet')
+      .attr('role', 'img')
+      .attr('aria-label', 'Radial coursework map with zoomable clusters');
 
     const g = svg.append('g');
-    let focus = root;
-    let view;
 
-    const circle = g
-      .selectAll('circle')
-      .data(nodes)
-      .enter()
+    const link = g
+      .append('g')
+      .attr('class', 'links')
+      .selectAll('path')
+      .data(root.links())
+      .join('path')
+      .attr('class', 'link')
+      .attr('stroke', (d) => blendWithSurface(colourFor(topCategory(d.target)), 0.45))
+      .attr(
+        'd',
+        d3
+          .linkRadial()
+          .angle((d) => d.x)
+          .radius((d) => d.y)
+      );
+
+    const node = g
+      .append('g')
+      .attr('class', 'nodes')
+      .selectAll('g')
+      .data(root.descendants())
+      .join('g')
+      .attr('class', 'node')
+      .attr('transform', (d) => `rotate(${(d.x * 180) / Math.PI - 90}) translate(${d.y},0)`);
+
+    node
       .append('circle')
-      .attr('class', (d) => (d.parent ? (d.children ? 'node' : 'node node--leaf') : 'node node--root'))
-      .style('fill', (d) => (d.children ? color(d.depth) : 'color-mix(in oklab, var(--accent) 60%, var(--bg) 40%)'))
-      .on('click', (event, d) => (focus !== d ? (zoom(event, d), event.stopPropagation()) : null));
-
-    const label = g
-      .selectAll('text')
-      .data(nodes)
-      .enter()
-      .append('text')
-      .attr('class', 'label')
-      .style('fill-opacity', (d) => (d.parent === root ? 1 : 0))
-      .style('display', (d) => (d.parent === root ? 'inline' : 'none'))
-      .text((d) => d.data.name);
-
-    const tooltip = document.createElement('div');
-    tooltip.className = 'tooltip';
-    tooltip.style.display = 'none';
-    el.appendChild(tooltip);
-
-    svg.on('click', (event) => zoom(event, root));
-
-    // Hover tooltip for leaf nodes
-    circle
-      .on('mousemove', (event, d) => {
-        if (d.children) {
-          tooltip.style.display = 'none';
-          return;
-        }
-        const pt = d3.pointer(event, el);
-        tooltip.textContent = d.data.name;
-        tooltip.style.left = pt[0] + 'px';
-        tooltip.style.top = pt[1] + 'px';
-        tooltip.style.display = 'block';
+      .attr('r', (d) => nodeRadius(d))
+      .attr('fill', (d) => {
+        if (d.depth === 0) return blendWithSurface('#64748b', 0.4);
+        const cat = topCategory(d);
+        const base = colourFor(cat);
+        const t = d.children ? (d.depth === 1 ? 0.52 : 0.7) : 0.88;
+        return blendWithSurface(base, t);
       })
-      .on('mouseleave', () => {
-        tooltip.style.display = 'none';
+      .attr('fill-opacity', (d) => (d.children ? 0.95 : 1))
+      .style('cursor', (d) => (d.children ? 'pointer' : 'default'))
+      .attr('stroke', borderColour)
+      .on('click', (event, d) => {
+        event.stopPropagation();
+        if (focus === d) return;
+        zoom(d, event);
+      })
+      .on('mouseenter', (event, d) => {
+        const meta = !d.children ? courseMap.get(d.data.id || d.data.code || d.data.name) : null;
+        const label = d.children
+          ? `${d.data.name} · ${d.leaves().length} course${d.leaves().length === 1 ? '' : 's'}`
+          : formatCourse(meta);
+        showTooltip(tooltip, event, label);
+      })
+      .on('mousemove', (event, d) => {
+        const meta = !d.children ? courseMap.get(d.data.id || d.data.code || d.data.name) : null;
+        const label = d.children
+          ? `${d.data.name} · ${d.leaves().length} course${d.leaves().length === 1 ? '' : 's'}`
+          : formatCourse(meta);
+        showTooltip(tooltip, event, label);
+      })
+      .on('mouseleave', () => hideTooltip(tooltip));
+
+    node
+      .append('text')
+      .attr('class', 'node-label')
+      .attr('dy', '0.32em')
+      .attr('x', (d) => {
+        const offset = nodeRadius(d) + 8;
+        return d.x < Math.PI ? offset : -offset;
+      })
+      .attr('text-anchor', (d) => (d.x < Math.PI ? 'start' : 'end'))
+      .attr('transform', (d) => (d.x >= Math.PI ? 'rotate(180)' : null))
+      .text((d) => {
+        if (d.depth === 0) return 'Coursework';
+        if (d.depth === 1) return d.data.name;
+        if (!d.children) {
+          const meta = courseMap.get(d.data.id || d.data.code || d.data.name);
+          return meta?.code || d.data.name;
+        }
+        return d.data.name;
       });
 
-    zoomTo([root.x, root.y, root.r * 2]);
+    let focus = root;
+    let view = [0, 0, diameter];
+
+    svg.on('click', () => {
+      if (focus !== root) zoom(root);
+    });
+
+    zoomTo(view);
+    updateHighlight();
+
+    function zoom(target, event) {
+      focus = target;
+      const next = target === root ? [0, 0, diameter] : viewFor(target, diameter);
+      const transition = svg
+        .transition()
+        .duration(event?.altKey ? 1000 : 750)
+        .tween('zoom', () => {
+          const i = d3.interpolateZoom(view, next);
+          return (t) => zoomTo(i(t));
+        });
+
+      transition.on('end', updateHighlight);
+    }
 
     function zoomTo(v) {
-      const k = width / v[2];
+      const k = diameter / v[2];
       view = v;
-      label.attr('transform', (d) => `translate(${(d.x - v[0]) * k},${(d.y - v[1]) * k})`);
-      circle.attr('transform', (d) => `translate(${(d.x - v[0]) * k},${(d.y - v[1]) * k})`);
-      circle.attr('r', (d) => d.r * k);
+      g.attr('transform', `translate(${-v[0] * k},${-v[1] * k}) scale(${k})`);
     }
 
-    function zoom(event, d) {
-      focus = d;
-
-      const transition = svg.transition().duration(event?.altKey ? 10000 : 700).tween('zoom', () => {
-        const i = d3.interpolateZoom(view, [focus.x, focus.y, focus.r * 2]);
-        return (t) => zoomTo(i(t));
-      });
-
-      label
-        .filter(function (n) {
-          return n.parent === focus || this.style.display === 'inline';
-        })
-        .transition(transition)
-        .style('fill-opacity', (n) => (n.parent === focus ? 1 : 0))
-        .on('start', function (n) {
-          if (n.parent === focus) this.style.display = 'inline';
-        })
-        .on('end', function (n) {
-          if (n.parent !== focus) this.style.display = 'none';
-        });
+    function updateHighlight() {
+      const active = new Set(focus.descendants().concat(focus.ancestors ? focus.ancestors() : []));
+      node.classed('dimmed', (d) => !active.has(d));
+      link.classed('dimmed', (d) => !active.has(d.source) && !active.has(d.target));
     }
+    return baseSize;
+  }
 
-    // Build a simple non-JS fallback list if <noscript> content placeholder exists
-    const fallbackEl = document.getElementById('cw-fallback');
-    if (fallbackEl) {
-      const parts = [];
-      for (const cat of data.children || []) {
-        parts.push(`<h3>${cat.name}</h3>`);
-        parts.push('<ul>');
-        for (const c of cat.children || []) parts.push(`<li>${c.name}</li>`);
-        parts.push('</ul>');
+  function computeBaseSize(container) {
+    const rect = container.getBoundingClientRect();
+    const measured = Math.max(rect.width || 0, container.clientWidth || 0, mount.clientWidth || 0);
+    const viewport = typeof window !== 'undefined' ? window.innerWidth || 0 : 0;
+    const fallback = viewport
+      ? Math.max(Math.min(viewport - 80, 1150), 320)
+      : 960;
+    const candidate = Math.max(measured, fallback);
+    return Math.max(Math.min(candidate, 1300), viewport < 640 ? 320 : 560);
+  }
+
+  function blendWithSurface(color, weight) {
+    return d3.interpolateLab(surfaceColour, color)(weight);
+  }
+
+  function buildFallbackList(tree) {
+    const lines = [];
+    const root = d3.hierarchy(structuredCloneSafe(tree));
+    for (const category of root.children || []) {
+      lines.push(`<h3>${category.data.name}</h3>`);
+      for (const group of category.children || []) {
+        lines.push(`<h4>${group.data.name}</h4>`);
+        lines.push('<ul>');
+        for (const leaf of group.leaves()) {
+          const code = leaf.data.code ? `${leaf.data.code} · ` : '';
+          lines.push(`<li>${code}${leaf.data.name}</li>`);
+        }
+        lines.push('</ul>');
       }
-      fallbackEl.innerHTML = parts.join('');
     }
+    return lines.join('');
   }
 })();
-

--- a/app/views/pages.py
+++ b/app/views/pages.py
@@ -6,8 +6,17 @@ from datetime import datetime
 from ..services.content import Page, Post, list_posts, syntax_highlight_css
 
 
-def _layout(title: str, body: str, theme: str | None = None, current_path: str = "/") -> str:
+def _layout(
+    title: str,
+    body: str,
+    theme: str | None = None,
+    current_path: str = "/",
+    *,
+    body_class: str = "",
+    extra_head: str = "",
+) -> str:
     theme_attr = f" data-theme=\"{theme}\"" if theme else ""
+    class_attr = f" class=\"{body_class}\"" if body_class else ""
     return f"""
 <!doctype html>
 <html lang=\"en\"{theme_attr}>
@@ -16,9 +25,10 @@ def _layout(title: str, body: str, theme: str | None = None, current_path: str =
     <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
     <title>{title}</title>
     <link rel=\"stylesheet\" href=\"/static/base.css\" />
+    {extra_head}
     <style>{syntax_highlight_css()}</style>
   </head>
-  <body>
+  <body{class_attr}>
     <header>
       <nav>
         <a href=\"/\">About</a>
@@ -186,8 +196,16 @@ def render_coursework_page(theme: str | None = None, current_path: str = "/") ->
     body = """
     <section>
       <h1>Coursework</h1>
-      <p>An interactive map of my B.Tech coursework grouped by themes. Click a category to zoom in; hover over a course to see details. No grades or semesters shown.</p>
-      <div id=\"cw-viz\" class=\"cw\" aria-label=\"Interactive coursework visualization\"></div>
+      <p>A zoomable radial map showing how every course connects back to its parent field. Click a branch to dive into the cluster, or click the background to reset.</p>
+      <div id=\"cw-viz\" class=\"cw\" aria-label=\"Interactive radial coursework map\">
+        <figure>
+          <figcaption>
+            <h2>Radial tree of clusters</h2>
+            <p>Each top level branch represents Physics, Electronics, Mathematics, Computer Science, Economics, or Other courses. Zoom in to follow the breakdown from field → sub-field → individual module.</p>
+          </figcaption>
+          <div class=\"viz-canvas\" data-viz=\"radial\" aria-label=\"Radial coursework tree\"></div>
+        </figure>
+      </div>
       <noscript>
         <p><strong>Note:</strong> This visualization requires JavaScript. Below is a plain list as fallback.</p>
         <div id=\"cw-fallback\"></div>
@@ -196,5 +214,12 @@ def render_coursework_page(theme: str | None = None, current_path: str = "/") ->
     <script src=\"https://cdn.jsdelivr.net/npm/d3@7\"></script>
     <script src=\"/static/coursework.js\"></script>
     """
-    return _layout("Coursework", body, theme=theme, current_path=current_path)
+    return _layout(
+        "Coursework",
+        body,
+        theme=theme,
+        current_path=current_path,
+        body_class="wide",
+        extra_head='<link rel="stylesheet" href="/static/coursework.css" />',
+    )
 


### PR DESCRIPTION
## Summary
- add a dedicated coursework stylesheet and widen the coursework layout while keeping header and footer aligned
- refactor the radial D3 renderer to remove inline styles, react to resize events, and use theme-aware colour blending that works in production
- extend the base layout helper to support custom body classes and extra head links for page-specific assets

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68dba27ab1f8832abfa75bc763c7e027