### PR TITLE
Improve responsive spacing for navigation and about page

### DIFF
--- a/app/static/base.css
+++ b/app/static/base.css
@@ -76,3 +76,16 @@ html[data-theme="dark"] .about-tagline{color:rgba(230,237,243,.75)}
   .about-card{width:100%}
   .about-content{order:-1}
 }
+@media (max-width:640px){
+  body{padding:0 .9rem}
+  header nav{flex-wrap:wrap;justify-content:center;gap:.75rem 1rem;padding:1rem 0 .75rem}
+  header nav a{font-size:.95rem;padding:.35rem .65rem}
+  #theme-toggle{margin-left:0;margin-right:0;order:-1;padding:.35rem .65rem}
+  main{padding:1rem 0}
+  footer{padding:1.5rem 0;margin-top:1.5rem}
+  .about-layout{gap:1.5rem}
+  .about-sidebar{gap:1.25rem}
+  .about-card{padding:1rem}
+  .about-body{font-size:1rem;gap:1.25rem}
+  .about-body p{max-width:none}
+}


### PR DESCRIPTION
## Summary
- adjust navigation spacing to wrap neatly on phones and bring the theme toggle into an easy-to-tap row
- soften spacing on the about layout so cards and body text are easier to scan on small screens

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ea313344d0832ab2b8d44eefa9934b